### PR TITLE
use doryo theme path in vite dockerfile

### DIFF
--- a/Dockerfile.vite
+++ b/Dockerfile.vite
@@ -3,11 +3,11 @@ FROM --platform=linux/arm64 node:18-alpine
 WORKDIR /app
 
 # Install dependencies
-COPY wp-content/themes/hello-child/package*.json ./
+COPY wp-content/themes/doryo-theme/package*.json ./
 RUN npm ci
 
 # Copy source code
-COPY wp-content/themes/hello-child/ .
+COPY wp-content/themes/doryo-theme/ .
 
 # Expose port
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- copy doryo theme dependency files in Vite Dockerfile
- copy doryo theme source code in Vite Dockerfile

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895be01a6b08320a753583160ec8617