### PR TITLE
Guard jQuery initialization in theme startup

### DIFF
--- a/wp-content/themes/doryo-theme/assets/js/main.ts
+++ b/wp-content/themes/doryo-theme/assets/js/main.ts
@@ -29,9 +29,11 @@ class HelloChildApp {
     });
 
     // Initialize components that need jQuery
-    window.jQuery(document).ready(() => {
-      this.initializeJQueryComponents();
-    });
+    if (typeof window.jQuery !== 'undefined') {
+      window.jQuery(document).ready(() => {
+        this.initializeJQueryComponents();
+      });
+    }
   }
 
   private initializeComponents(): void {


### PR DESCRIPTION
## Summary
- Avoid runtime errors when jQuery isn't loaded by checking for it before initializing jQuery-dependent components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint:js` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*
- `npm run type-check` *(fails: Cannot find type definition file for 'jquery'; Cannot find type definition file for 'wordpress__blocks')*

------
https://chatgpt.com/codex/tasks/task_e_6895bbc0b4d88320847bb8518c441fd5