### PR TITLE
Align JS globals with theme namespace

### DIFF
--- a/wp-content/themes/doryo-theme/assets/js/admin.ts
+++ b/wp-content/themes/doryo-theme/assets/js/admin.ts
@@ -5,7 +5,7 @@ declare global {
     jQuery: any;
     $: any;
     wp: any;
-    helloChild: {
+    doryoTheme: {
       ajaxUrl: string;
       nonce: string;
       restUrl: string;
@@ -14,7 +14,7 @@ declare global {
   }
 }
 
-class HelloChildAdmin {
+class DoryoThemeAdmin {
   constructor() {
     this.init();
   }
@@ -26,7 +26,7 @@ class HelloChildAdmin {
   }
 
   private initializeAdminFeatures(): void {
-    console.log('Hello Child Admin initialized');
+    console.log('Doryo Theme Admin initialized');
     
     // Add admin-specific functionality here
     this.setupCustomMetaBoxes();
@@ -45,4 +45,4 @@ class HelloChildAdmin {
 }
 
 // Initialize admin functionality
-new HelloChildAdmin();
+new DoryoThemeAdmin();

--- a/wp-content/themes/doryo-theme/assets/js/main.ts
+++ b/wp-content/themes/doryo-theme/assets/js/main.ts
@@ -8,7 +8,7 @@ declare global {
     jQuery: JQueryStatic;
     $: JQueryStatic;
     wp: any;
-    helloChild: {
+    doryoTheme: {
       ajaxUrl: string;
       nonce: string;
       restUrl: string;
@@ -17,7 +17,7 @@ declare global {
   }
 }
 
-class HelloChildApp {
+class DoryoThemeApp {
   constructor() {
     this.init();
   }
@@ -35,7 +35,7 @@ class HelloChildApp {
   }
 
   private initializeComponents(): void {
-    console.log('Hello Child Theme initialized');
+    console.log('Doryo Theme initialized');
     
     // Initialize theme components
     initializeTheme();
@@ -61,4 +61,4 @@ class HelloChildApp {
 }
 
 // Initialize the application
-new HelloChildApp();
+new DoryoThemeApp();


### PR DESCRIPTION
## Summary
- keep `wp_localize_script` namespace `doryoTheme`
- rename TypeScript globals and classes from `helloChild` to `doryoTheme`

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjquery)*
- `npm run build` *(fails: vite: not found)*
- `npm run type-check` *(fails: Cannot find type definition file for 'jquery')*
- `npm run lint:js` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm run lint:php` *(fails: phpcs: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895be679cf4832086ad1b819cb090c9