### PR TITLE
Ensure Vite dev scripts load as modules

### DIFF
--- a/wp-content/themes/doryo-theme/functions.php
+++ b/wp-content/themes/doryo-theme/functions.php
@@ -83,6 +83,7 @@ class DoryoTheme {
                 null,
                 true
             );
+            wp_script_add_data('doryo-theme-admin', 'type', 'module');
         } else {
             $admin_asset = $this->get_vite_asset('assets/js/admin.ts');
             if ($admin_asset) {
@@ -108,7 +109,8 @@ class DoryoTheme {
             null,
             false // Im Head laden
         );
-        
+        wp_script_add_data('vite-hmr-client', 'type', 'module');
+
         // 2. SCSS als JavaScript-Modul laden (wichtig für HMR!)
         wp_enqueue_script(
             'doryo-theme-style-hmr',
@@ -117,7 +119,8 @@ class DoryoTheme {
             null,
             false // Im Head laden
         );
-        
+        wp_script_add_data('doryo-theme-style-hmr', 'type', 'module');
+
         // 3. Main JS Entry Point
         wp_enqueue_script(
             'doryo-theme-main-hmr',
@@ -126,6 +129,7 @@ class DoryoTheme {
             null,
             true
         );
+        wp_script_add_data('doryo-theme-main-hmr', 'type', 'module');
         
         // Debug-Info
         error_log('Doryo Theme: HMR assets loaded:');


### PR DESCRIPTION
## Summary
- mark Vite HMR client and dev scripts as ES modules
- treat admin script as module when Vite dev server runs

## Testing
- `php -l wp-content/themes/doryo-theme/functions.php`
- `composer test` *(fails: phpunit: not found)*
- `composer install` *(fails: curl error 56 while downloading https://wpackagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895de83a5688320b2f50a9572b43aa6